### PR TITLE
fix: Add support to store hls part files to disk

### DIFF
--- a/examples/muxer/main.go
+++ b/examples/muxer/main.go
@@ -50,6 +50,8 @@ func main() {
 				},
 			},
 		},
+		Directory:    "/Users/karthik/Downloads/hls/",
+		SegmentCount: 999999,
 	}
 	err := mux.Start()
 	if err != nil {

--- a/muxer_part.go
+++ b/muxer_part.go
@@ -31,6 +31,7 @@ type muxerPart struct {
 	videoStartDTS       time.Duration
 	audioStartDTSFilled bool
 	audioStartDTS       time.Duration
+	factory				storage.Factory
 }
 
 func (p *muxerPart) initialize() {
@@ -78,6 +79,16 @@ func (p *muxerPart) finalize(nextDTS time.Duration) error {
 	if err != nil {
 		return err
 	}
+
+
+	f, err := p.factory.NewFile(p.name)
+	if err != nil {
+		return err
+	}
+	defer f.Finalize()
+	newPart := f.NewPart()
+	w := newPart.Writer()
+	err = part.Marshal(w)
 
 	p.finalDuration = p.computeDuration(nextDTS)
 

--- a/muxer_part.go
+++ b/muxer_part.go
@@ -31,7 +31,7 @@ type muxerPart struct {
 	videoStartDTS       time.Duration
 	audioStartDTSFilled bool
 	audioStartDTS       time.Duration
-	factory				storage.Factory
+	factory             storage.Factory
 }
 
 func (p *muxerPart) initialize() {
@@ -80,15 +80,18 @@ func (p *muxerPart) finalize(nextDTS time.Duration) error {
 		return err
 	}
 
-
 	f, err := p.factory.NewFile(p.name)
 	if err != nil {
 		return err
 	}
 	defer f.Finalize()
-	newPart := f.NewPart()
-	w := newPart.Writer()
-	err = part.Marshal(w)
+	file := f.NewPart()
+	file_writer := file.Writer()
+	err = part.Marshal(file_writer)
+
+	if err != nil {
+		return err
+	}
 
 	p.finalDuration = p.computeDuration(nextDTS)
 

--- a/muxer_segment_fmp4.go
+++ b/muxer_segment_fmp4.go
@@ -49,6 +49,7 @@ func (s *muxerSegmentFMP4) initialize() error {
 		prefix:         s.prefix,
 		id:             s.takePartID(),
 		storage:        s.storage.NewPart(),
+		factory:		s.factory,
 	}
 	s.currentPart.initialize()
 
@@ -139,6 +140,7 @@ func (s *muxerSegmentFMP4) writeVideo(
 			prefix:         s.prefix,
 			id:             s.takePartID(),
 			storage:        s.storage.NewPart(),
+			factory:		s.factory,
 		}
 		s.currentPart.initialize()
 	}
@@ -181,6 +183,7 @@ func (s *muxerSegmentFMP4) writeAudio(
 			prefix:         s.prefix,
 			id:             s.takePartID(),
 			storage:        s.storage.NewPart(),
+			factory:		s.factory,
 		}
 		s.currentPart.initialize()
 	}


### PR DESCRIPTION
- For llhls 200ms part files will be generated, but right now they are being stored in-memory. Scalability is getting affected in this case.
- So to fix this, we are adding support to store it in disk.

