### PR TITLE
 fix: Add support to provide directory and input url from command line

### DIFF
--- a/examples/muxer/main.go
+++ b/examples/muxer/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	_ "embed"
+	"flag"
 	"log"
 	"net"
 	"net/http"
@@ -36,6 +37,11 @@ func handleIndex(wrapped http.HandlerFunc) http.HandlerFunc {
 }
 
 func main() {
+	directory := flag.String("dir", "", "Directory for HLS files")
+	udpAddress := flag.String("udp", "localhost:9000", "UDP address to listen for MPEG-TS packets")
+
+	flag.Parse()
+
 	// create the HLS muxer
 	mux := &gohlslib.Muxer{
 		VideoTrack: &gohlslib.Track{
@@ -50,7 +56,7 @@ func main() {
 				},
 			},
 		},
-		Directory:    "/Users/karthik/Downloads/hls/",
+		Directory:    *directory,
 		SegmentCount: 999999,
 	}
 	err := mux.Start()
@@ -67,17 +73,13 @@ func main() {
 	go s.ListenAndServe()
 
 	// create a socket to receive MPEG-TS packets
-	pc, err := net.ListenPacket("udp", "localhost:9000")
+	pc, err := net.ListenPacket("udp", *udpAddress)
 	if err != nil {
 		panic(err)
 	}
 	defer pc.Close()
 
-	log.Println("Waiting for a MPEG-TS/H264 stream on UDP port 9000 - you can send one with GStreamer:\n" +
-		"gst-launch-1.0 videotestsrc ! video/x-raw,width=1920,height=1080" +
-		" ! x264enc speed-preset=ultrafast bitrate=3000 key-int-max=60" +
-		" ! video/x-h264,profile=high" +
-		" ! mpegtsmux alignment=6 ! udpsink host=127.0.0.1 port=9000")
+	log.Println("Waiting for a MPEG-TS/H264 stream on UDP port ", *udpAddress)
 
 	// create a MPEG-TS reader
 	r, err := mpegts.NewReader(mpegts.NewBufferedReader(newPacketConnReader(pc)))


### PR DESCRIPTION
- Previously the directory to store output and input url was hardcoded.
- We added support to provide it from command line
- ./muxer -dir "/home/directory/" -udp "localhost:9000"

