### PR TITLE
fix: Add multivariant support

### DIFF
--- a/examples/muxer/main.go
+++ b/examples/muxer/main.go
@@ -109,6 +109,15 @@ func setupMPEGTSReader(pc net.PacketConn, resolution string, directory string) {
 		VideoTrack: &gohlslib.Track{
 			Codec: &codecs.H264{},
 		},
+		AudioTrack: &gohlslib.Track{
+			Codec: &codecs.MPEG4Audio{
+				Config: mpeg4audio.Config{
+					Type:         2,
+					SampleRate:   44100,
+					ChannelCount: 2,
+				},
+			},
+		},
 		Directory:    directory,
 		SegmentCount: 999999,
 		Prefix:       resolution,

--- a/muxer.go
+++ b/muxer.go
@@ -80,7 +80,7 @@ type Muxer struct {
 	SegmentDuration time.Duration
 	// Deprecated: replaced with PartMinDUratino
 	PartDuration time.Duration
-
+	Prefix string
 	//
 	// private
 	//
@@ -145,7 +145,7 @@ func (m *Muxer) Start() error {
 	}
 
 	var err error
-	m.prefix, err = generatePrefix()
+	m.prefix = m.Prefix
 	if err != nil {
 		return err
 	}
@@ -369,4 +369,22 @@ func (m *Muxer) WriteMPEG4Audio(ntp time.Time, pts time.Duration, aus [][]byte) 
 // Handle handles a HTTP request.
 func (m *Muxer) Handle(w http.ResponseWriter, r *http.Request) {
 	m.server.handle(w, r)
+}
+
+
+func (m *Muxer) GetVariant() string {
+	return string(m.server.multivariantPlaylist)
+}
+
+
+func (m *Muxer) GenerateMainManifest(data string) {
+	file, err := m.storageFactory.NewFile("video.m3u8")
+	if err != nil {
+		fmt.Println("Failed to create file(video.m3u8): %s", err)
+	}
+
+	dataBytes := []byte(data)
+	newPart := file.NewPart()
+	w := newPart.Writer()
+	_, err = w.Write(dataBytes)
 }

--- a/muxer_server.go
+++ b/muxer_server.go
@@ -1,6 +1,7 @@
 package gohlslib
 
 import (
+	"fmt"
 	"io"
 	"math"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"fmt"
 
 	"github.com/bluenviron/mediacommon/pkg/codecs/av1"
 	"github.com/bluenviron/mediacommon/pkg/codecs/h264"
@@ -295,7 +295,7 @@ func generateMediaPlaylistFMP4(
 		partHoldBack := (partTarget * 25) / 10
 
 		pl.ServerControl = &playlist.MediaServerControl{
-			CanBlockReload: true,
+			CanBlockReload: false,
 			PartHoldBack:   &partHoldBack,
 			CanSkipUntil:   &skipBoundary,
 		}

--- a/muxer_server.go
+++ b/muxer_server.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"fmt"
 
 	"github.com/bluenviron/mediacommon/pkg/codecs/av1"
 	"github.com/bluenviron/mediacommon/pkg/codecs/h264"
@@ -759,12 +760,38 @@ func (s *muxerServer) publishPartInner(part *muxerPart) error {
 
 func (s *muxerServer) publishPart(part *muxerPart) error {
 	s.mutex.Lock()
+
 	err := s.publishPartInner(part)
 	s.mutex.Unlock()
 	if err != nil {
 		return err
 	}
 
+	byts, err := func() ([]byte, error) {
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
+
+		return generateMediaPlaylist(
+			false,
+			s.variant,
+			s.segments,
+			s.nextSegmentParts,
+			s.nextPartID,
+			s.segmentDeleteCount,
+			s.prefix,
+		)
+	}()
+
+	fileName := "video_" + s.prefix + ".m3u8"
+	file, err := s.storageFactory.NewFile(fileName)
+	if err != nil {
+		fmt.Println("failed to create file(%s): %s", fileName, err)
+		return err
+	}
+	newPart := file.NewPart()
+	w := newPart.Writer()
+
+	_, err = w.Write(byts)
 	s.cond.Broadcast()
 	return nil
 }


### PR DESCRIPTION
- This commit adds support to generate llhls for multiple resolutions.
- `muxer -dir "/home/ubuntu/livestream" -udps "localhost:9000|720p|1280x720|1000000,localhost:9001|480p|854x480|500000"`